### PR TITLE
fix: `categories` in `useCategories` return `null` issue

### DIFF
--- a/frontend/src/api/categoryApi.ts
+++ b/frontend/src/api/categoryApi.ts
@@ -3,8 +3,15 @@ import checkResponse from './checkResponse';
 
 export const BASE_URL = API_URL;
 
-export const fetchAll = (token: string) => {
-  console.log(import.meta.env);
+export type Category = {
+  id: number;
+  name: string;
+  color: string;
+  icon: string;
+  total_tasks: number;
+};
+
+export const fetchAll = (token: string): Promise<Category[]> => {
   return fetch(`${BASE_URL}/v1/categories`, {
     method: 'GET',
     headers: {

--- a/frontend/src/hooks/useCategories.ts
+++ b/frontend/src/hooks/useCategories.ts
@@ -2,21 +2,15 @@ import { useCallback, useEffect, useState } from 'react';
 
 import * as categoriesAPI from '../api/categoryApi';
 
-type Category = {
-  id: number;
-  name: string;
-  color: string;
-  icon: string;
-  total_tasks: number;
-};
+import type { Category } from '../api/categoryApi';
 
 const useCategories = (token: string | null) => {
-  const [categories, setCategories] = useState<Category[] | null>(null);
+  const [categories, setCategories] = useState<Category[]>([]);
 
   const fetchAllCategories = useCallback(async (token: string | null) => {
-    if (!token) return;
+    if (!token) return [];
     try {
-      const categories = (await categoriesAPI.fetchAll(token)) as Category[];
+      const categories = await categoriesAPI.fetchAll(token);
       setCategories(categories);
     } catch (error) {
       console.error(error);

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -12,7 +12,7 @@ import type TaskCard from '../../models/TaskCard';
 
 const MainPage = () => {
   const { allTasks, getTasks } = useTasksBoard();
-  const categories = useCategoriesContext();
+  const { categories } = useCategoriesContext();
   const { selectedCategories } = useContext(SelectedCategoriesContext);
   const [filteredTasksByCategory, setFilteredTasksByCategory] = useState([]);
   const [tasksToday, setTasksToday] = useState<TaskCard[]>([]);
@@ -21,32 +21,32 @@ const MainPage = () => {
 
   useEffect(() => {
     getTasks(allTasks);
-  }, [allTasks]);
+  }, [getTasks, allTasks]);
 
   useEffect(() => {
-    if (selectedCategories && categories) {
-      const filterTasksByCategory = (tasks, categories) => {
-        const categoriesMap = categories.reduce((acc, category) => {
-          acc[category.id] = category.name;
-          return acc;
-        }, {});
+    if (!allTasks?.length || !selectedCategories?.length || !categories?.length)
+      return;
+    const filterTasksByCategory = (tasks, categories) => {
+      const categoriesMap = categories.reduce((acc, category) => {
+        acc[category.id] = category.name;
+        return acc;
+      }, {});
 
-        return tasks.filter((task) => {
-          const categoryName = categoriesMap[task.category_id];
-          if (categoryName) {
-            task.categoryName = categoryName;
-            return true;
-          }
-          return false;
-        });
-      };
+      return tasks.filter((task) => {
+        const categoryName = categoriesMap[task.category_id];
+        if (categoryName) {
+          task.categoryName = categoryName;
+          return true;
+        }
+        return false;
+      });
+    };
 
-      const filteredTasksByCategory = filterTasksByCategory(
-        allTasks,
-        selectedCategories,
-      );
-      setFilteredTasksByCategory(filteredTasksByCategory);
-    }
+    const filteredTasksByCategory = filterTasksByCategory(
+      allTasks,
+      selectedCategories,
+    );
+    setFilteredTasksByCategory(filteredTasksByCategory);
   }, [allTasks, categories, selectedCategories]);
 
   const today = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
Initially I set `useState<Category[]>(null)` which highly possible will be null, this is the root cause of why invoker crashes.

I now set it default to an empty array `useState<Category[]>([])`, and also put some defenses on the invoker side, which ensure this crash case won't happen again.