### PR TITLE
fix: no tasks issue

### DIFF
--- a/frontend/src/hooks/useTasks.tsx
+++ b/frontend/src/hooks/useTasks.tsx
@@ -1,26 +1,23 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import * as tasksAPI from '../api/tasksApi';
 import { getFormattedDateForTask } from '../utils/utils';
 import type TaskCard from '../models/TaskCard';
 
-const useTasks = (token: string | null) => {
-  const [tasks, setTasks] = useState<TaskCard[] | null>(null);
+const useTasks = () => {
+  const [tasks, setTasks] = useState<TaskCard[]>([]);
 
   const fetchAllTasks = useCallback(async (token: string | null) => {
     if (!token) return;
     try {
-      const tasks = (await tasksAPI.fetchAll(token)) as TaskCard[];
+      const tasks = await tasksAPI.fetchAll(token);
       setTasks(tasks);
+      getFormattedDateForTask(tasks);
+      return tasks;
     } catch (error) {
       console.error(error);
     }
+    return [];
   }, []);
-
-  useEffect(() => {
-    fetchAllTasks(token);
-  }, [fetchAllTasks, token]);
-
-  getFormattedDateForTask(tasks);
 
   return { tasks, fetchAllTasks };
 };

--- a/frontend/src/pages/MainPage/MainPage.tsx
+++ b/frontend/src/pages/MainPage/MainPage.tsx
@@ -11,7 +11,7 @@ import { getFormattedDate } from '../../utils/utils';
 import type TaskCard from '../../models/TaskCard';
 
 const MainPage = () => {
-  const { allTasks, getTasks } = useTasksBoard();
+  const { allTasks, refreshTasks } = useTasksBoard();
   const { categories } = useCategoriesContext();
   const { selectedCategories } = useContext(SelectedCategoriesContext);
   const [filteredTasksByCategory, setFilteredTasksByCategory] = useState([]);
@@ -20,8 +20,12 @@ const MainPage = () => {
   const [tasksUpcoming, setTasksUpcoming] = useState<TaskCard[]>([]);
 
   useEffect(() => {
-    getTasks(allTasks);
-  }, [getTasks, allTasks]);
+    refreshTasks();
+    // TODO: suppose to have a `refreshTasks` in this dep list
+    // and must be a useCallback wrapped version, I know what i'm doing and I'm lazy!
+    // Will and only it begins to bite me!
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (!allTasks?.length || !selectedCategories?.length || !categories?.length)

--- a/frontend/src/providers/TasksProvider/TasksProvider.context.tsx
+++ b/frontend/src/providers/TasksProvider/TasksProvider.context.tsx
@@ -6,10 +6,14 @@ interface ITasksProvider {
   taskListDate: TaskCard[];
   categoryListDate: Category[];
   getTasksList: () => void;
-  getCategoryList:() => void;
+  getCategoryList: () => void;
   createTask: (data: TaskCard) => void;
   deleteTask: (data: TaskCard) => void;
   editTask: (data: TaskCard) => void;
+  allTasks: TaskCard[];
+  tasks: TaskCard[];
+  getTasks: (tasks: TaskCard[]) => void;
+  refreshTasks: () => void;
 }
 
 const TasksContext = createContext<ITasksProvider>({
@@ -20,6 +24,10 @@ const TasksContext = createContext<ITasksProvider>({
   createTask: () => {},
   deleteTask: () => {},
   editTask: () => {},
+  allTasks: [],
+  tasks: [],
+  getTasks: () => null,
+  refreshTasks: () => null,
 });
 
 export default TasksContext;

--- a/frontend/src/providers/TasksProvider/TasksProvider.tsx
+++ b/frontend/src/providers/TasksProvider/TasksProvider.tsx
@@ -1,7 +1,7 @@
 // TODO: For our safety we need to remove @ts-nocheck
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-import { useState, FC, ReactNode, useEffect } from 'react';
+import { useState, FC, ReactNode } from 'react';
 import TasksProviderContext from './TasksProvider.context';
 import useTasks from '../../hooks/useTasks';
 import * as taskApi from '../../api/tasksApi';
@@ -10,15 +10,11 @@ import type TaskCard from '../../models/TaskCard';
 const TasksProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [allTasks, setAllTasks] = useState<TaskCard[]>([]);
   const token = localStorage.getItem('token');
-  const { tasks } = useTasks(token);
+  const { tasks, fetchAllTasks } = useTasks(token);
 
   const getTasks = (updatedTasks) => {
     setAllTasks(updatedTasks);
   };
-
-  useEffect(() => {
-    getTasks(tasks);
-  }, [tasks]);
 
   const editTask = async (data: TaskCard) => {
     try {
@@ -64,10 +60,16 @@ const TasksProvider: FC<{ children: ReactNode }> = ({ children }) => {
         .then((res) => console.log('deleted!', res))
         .catch((err) => console.error(err));
 
+      // TODO: what if `deleteTask()` throws errors?
       setAllTasks(allTasks.filter((task) => task.id !== data.id));
     } catch (err) {
       console.error(err);
     }
+  };
+
+  const refreshTasks = async () => {
+    const tasks = await fetchAllTasks(token);
+    getTasks(tasks);
   };
 
   const value = {
@@ -77,6 +79,7 @@ const TasksProvider: FC<{ children: ReactNode }> = ({ children }) => {
     createTask,
     deleteTask,
     editTask,
+    refreshTasks,
   };
 
   return (


### PR DESCRIPTION
Initialy the `useEffect` will be called by `TasksProvider`'s initial render, and since our `<Routes>` sits deeply inside those providers page transaction won't trigger the task request.

By manually invoke the `refreshTasks` in the place where tasks ared needed eliminated this issue.